### PR TITLE
Implement mailing on register and extra validation on registration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>
-			<version>3.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.13.1</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+			<version>3.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/bdm/controller/AuthController.java
+++ b/src/main/java/com/example/bdm/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.example.bdm.controller;
 import com.example.bdm.dto.*;
 import com.example.bdm.exception.EmailAlreadyExistsException;
 import com.example.bdm.exception.NoSuchRoleException;
+import com.example.bdm.exception.RegistrationActivationFailedException;
 import com.example.bdm.model.AppUser;
 import com.example.bdm.service.AuthService;
 import jakarta.servlet.http.Cookie;
@@ -13,6 +14,8 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.NoSuchElementException;
 
 @RestController
 @RequestMapping("api/auth")
@@ -63,6 +66,24 @@ public class AuthController {
         Cookie expiredCookie = authService.generateExpiredCookie();
         response.addCookie(expiredCookie);
         return ResponseEntity.ok().body("User disconnected");
+    }
+
+    @GetMapping("/activate/{token}")
+    public ResponseEntity<?> getById(@PathVariable String token) {
+        try {
+            boolean isSuccess = authService.validateRegistrationToken(token);
+            if(!isSuccess){
+                throw new RegistrationActivationFailedException();
+            }
+            return ResponseEntity.ok("User has been validated");
+        } catch (RegistrationActivationFailedException e) {
+            return ResponseEntity.status(400).body(e.getMessage());
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.status(404).body("No corresponding user found");
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body("Could not retrieve user due to internal error");
+        }
     }
 
 }

--- a/src/main/java/com/example/bdm/controller/AuthController.java
+++ b/src/main/java/com/example/bdm/controller/AuthController.java
@@ -1,11 +1,12 @@
 package com.example.bdm.controller;
 
 import com.example.bdm.dto.*;
-import com.example.bdm.exception.EmailAlreadyExistsException;
-import com.example.bdm.exception.NoSuchRoleException;
-import com.example.bdm.exception.RegistrationActivationFailedException;
+import com.example.bdm.exception.*;
 import com.example.bdm.model.AppUser;
 import com.example.bdm.service.AuthService;
+import com.example.bdm.utils.SanitizerUtil;
+import com.example.bdm.utils.ValidatorUtil;
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @RestController
@@ -22,23 +24,42 @@ import java.util.NoSuchElementException;
 public class AuthController {
 
     private final AuthService authService;
+    private final SanitizerUtil sanitizerUtil;
+    private final ValidatorUtil validatorUtil;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, SanitizerUtil sanitizerUtil, ValidatorUtil validatorUtil) {
         this.authService = authService;
-
+        this.sanitizerUtil = sanitizerUtil;
+        this.validatorUtil = validatorUtil;
     }
 
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@RequestBody RequestRegister request) {
         try{
-            authService.registerNewUser(request);
-
-            return ResponseEntity.ok("User registered");
-        } catch (EmailAlreadyExistsException e){
+            RequestRegister sanitizedRequest = sanitizerUtil.sanitizeRegisterInputs(request);
+            List<String> validationErrors = validatorUtil.validateRegisterInputs(sanitizedRequest);
+            boolean isRequestInvalid = !validationErrors.isEmpty();
+            if (isRequestInvalid){
+                ErrorsDto errorsDto = new ErrorsDto(validationErrors);
+                return ResponseEntity.badRequest().body(errorsDto);
+            } else {
+                authService.registerNewUser(sanitizedRequest);
+                return ResponseEntity.ok("User registered");
+            }
+        } catch (InvalidRegistrationInputException e) {
             return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (NoSuchRoleException e){
+        } catch (EmailAlreadyExistsException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        } catch (NoSuchRoleException e) {
             e.printStackTrace();
             return ResponseEntity.internalServerError().body(e.getMessage());
+        } catch (UserNotCreatedException e) {
+            e.printStackTrace();
+            return ResponseEntity.internalServerError().body(e.getMessage());
+        } catch (MessagingException e) {
+            e.printStackTrace();
+            String message = "user was created but an error occured when sending the validation email";
+            return ResponseEntity.internalServerError().body(message);
         } catch (Exception e){
             e.printStackTrace();
             return ResponseEntity.internalServerError().body("An unexpected error occurred while processing the request");
@@ -75,14 +96,14 @@ public class AuthController {
             if(!isSuccess){
                 throw new RegistrationActivationFailedException();
             }
-            return ResponseEntity.ok("User has been validated");
+            return ResponseEntity.ok("Your account has been successfully validated");
         } catch (RegistrationActivationFailedException e) {
             return ResponseEntity.status(400).body(e.getMessage());
         } catch (NoSuchElementException e) {
-            return ResponseEntity.status(404).body("No corresponding user found");
+            return ResponseEntity.status(404).body("This activation link is invalid");
         } catch (Exception e) {
             e.printStackTrace();
-            return ResponseEntity.internalServerError().body("Could not retrieve user due to internal error");
+            return ResponseEntity.internalServerError().body("An unexpected error occured on the server");
         }
     }
 

--- a/src/main/java/com/example/bdm/dto/ErrorsDto.java
+++ b/src/main/java/com/example/bdm/dto/ErrorsDto.java
@@ -1,0 +1,29 @@
+package com.example.bdm.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ErrorsDto {
+    private List<String> errors;
+    ErrorsDto(){
+    }
+    public ErrorsDto(List<String> errors){
+        this.errors = errors;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+
+    public void addError(String errorMessage){
+        this.errors.add(errorMessage);
+    }
+
+    public void removeError(int index){
+        this.errors.remove(index);
+    }
+}

--- a/src/main/java/com/example/bdm/exception/ActivationTokenGenerationException.java
+++ b/src/main/java/com/example/bdm/exception/ActivationTokenGenerationException.java
@@ -1,0 +1,15 @@
+package com.example.bdm.exception;
+public class ActivationTokenGenerationException extends RuntimeException {
+
+    public ActivationTokenGenerationException(String message) {
+        super(message);
+    }
+
+    public ActivationTokenGenerationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ActivationTokenGenerationException() {
+        super("Failed to generate activation token on register");
+    }
+}

--- a/src/main/java/com/example/bdm/exception/InvalidRegistrationInputException.java
+++ b/src/main/java/com/example/bdm/exception/InvalidRegistrationInputException.java
@@ -1,0 +1,15 @@
+package com.example.bdm.exception;
+
+public class InvalidRegistrationInputException extends RuntimeException {
+    public InvalidRegistrationInputException(String message) {
+        super(message);
+    }
+
+    public InvalidRegistrationInputException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidRegistrationInputException() {
+        super("Invalid parameters given for registering");
+    }
+}

--- a/src/main/java/com/example/bdm/exception/RegistrationActivationFailedException.java
+++ b/src/main/java/com/example/bdm/exception/RegistrationActivationFailedException.java
@@ -1,0 +1,15 @@
+package com.example.bdm.exception;
+public class RegistrationActivationFailedException extends RuntimeException {
+
+    public RegistrationActivationFailedException(String message) {
+        super(message);
+    }
+
+    public RegistrationActivationFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RegistrationActivationFailedException() {
+        super("Invalid registration token");
+    }
+}

--- a/src/main/java/com/example/bdm/exception/UserNotCreatedException.java
+++ b/src/main/java/com/example/bdm/exception/UserNotCreatedException.java
@@ -10,6 +10,6 @@ public class UserNotCreatedException extends RuntimeException {
     }
 
     public UserNotCreatedException() {
-        super("A new user was not created due to an error");
+        super("A new user was not created during registration due to an error");
     }
 }

--- a/src/main/java/com/example/bdm/model/AppUser.java
+++ b/src/main/java/com/example/bdm/model/AppUser.java
@@ -94,7 +94,7 @@ public class AppUser {
         return isActive;
     }
 
-    public void setActive(boolean active) {
+    public void setIsActive(boolean active) {
         isActive = active;
     }
 

--- a/src/main/java/com/example/bdm/model/AppUser.java
+++ b/src/main/java/com/example/bdm/model/AppUser.java
@@ -63,6 +63,7 @@ public class AppUser {
     }
 
     public void setFirstName(String firstName) {
+
         this.firstName = firstName;
     }
 

--- a/src/main/java/com/example/bdm/repository/AppUserRepository.java
+++ b/src/main/java/com/example/bdm/repository/AppUserRepository.java
@@ -2,10 +2,16 @@ package com.example.bdm.repository;
 
 import com.example.bdm.model.AppUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
+import java.util.Set;
 
 public interface AppUserRepository extends JpaRepository<AppUser, Long> {
     boolean existsByEmail(String email);
     Optional<AppUser> findByEmail(String email);
+    Optional<AppUser> findByActivationToken(String activationToken);
+
+    @Query("SELECT u.activationToken FROM AppUser u WHERE u.activationToken IS NOT NULL")
+    Set<String> findAllNonNullActivationTokens();
 }

--- a/src/main/java/com/example/bdm/service/AuthService.java
+++ b/src/main/java/com/example/bdm/service/AuthService.java
@@ -13,6 +13,7 @@ import com.example.bdm.repository.AppUserRepository;
 import com.example.bdm.repository.RoleRepository;
 import com.example.bdm.utils.ActivationTokenUtil;
 import com.example.bdm.utils.JwtUtil;
+import jakarta.mail.MessagingException;
 import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
@@ -23,6 +24,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.Arrays;
@@ -43,25 +45,33 @@ public class AuthService {
     private PasswordEncoder passwordEncoder;
     private AuthenticationManager authManager;
     private JwtUtil jwtUtil;
+    private EmailService emailService;
 
     public AuthService(
             AppUserRepository userRepository,
             RoleRepository roleRepository,
             PasswordEncoder passwordEncoder,
             AuthenticationManager authManager,
-            JwtUtil jwtUtil) {
+            JwtUtil jwtUtil,
+            EmailService emailService) {
         this.userRepository = userRepository;
         this.roleRepository = roleRepository;
         this.passwordEncoder = passwordEncoder;
         this.authManager = authManager;
         this.jwtUtil = jwtUtil;
+        this.emailService = emailService;
     }
 
-    public AppUser registerNewUser(RequestRegister registerData){
+    /**
+     * Creates and persists a new user from signup data
+     * @param registerData
+     * @return
+     * @throws MessagingException
+     */
+    public AppUser registerNewUser(RequestRegister registerData) throws MessagingException {
         if (userRepository.existsByEmail(registerData.getEmail())) {
             throw new EmailAlreadyExistsException();
         }
-
             AppUser newUser = new AppUser();
             newUser.setFirstName(registerData.getFirstName());
             newUser.setLastName(registerData.getLastName());
@@ -71,11 +81,20 @@ public class AuthService {
             Role userRole = roleRepository.findByName(AvailableRoles.USER.toString())
                     .orElseThrow( () -> new NoSuchRoleException("The default user role has not been set up"));
             newUser.setRole(userRole);
+            String activationToken = generateRegistrationToken();
+            newUser.setActivationToken(activationToken);
             userRepository.save(newUser);
-            return userRepository.findByEmail(newUser.getEmail())
+            AppUser createdUser = userRepository.findByEmail(newUser.getEmail())
                     .orElseThrow(UserNotCreatedException::new);
+            emailService.sendRegistrationActivationEmail(createdUser, activationToken);
+            return createdUser;
     }
 
+    /**
+     * Gets and returns user corresponding to credentials if such a user exists
+     * @param request
+     * @return
+     */
     public AppUser getUserFromLogin(RequestLogin request){
         Authentication auth = authManager.authenticate(
                 new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
@@ -83,6 +102,11 @@ public class AuthService {
         return userRepository.findByEmail(userDetails.getUsername()).orElseThrow();
     }
 
+    /**
+     * Generates the cookie containing the token representing a logged user
+     * @param loggedUser
+     * @return cookie
+     */
     public ResponseCookie generateCookieFromUser(AppUser loggedUser){
         String token = jwtUtil.generateToken(loggedUser);
 //        boolean mustBeSecure = Arrays.asList(environment.getActiveProfiles()).contains("prod");
@@ -95,6 +119,10 @@ public class AuthService {
                 .build();
     }
 
+    /**
+     * Generates a expired jwt cookie to be send and remove the jwt cookie
+     * @return Cookie
+     */
     public Cookie generateExpiredCookie() {
 //        boolean mustBeSecure = Arrays.asList(environment.getActiveProfiles()).contains("prod");
         Cookie cookie = new Cookie("jwt", null);
@@ -105,23 +133,34 @@ public class AuthService {
         return cookie;
     }
 
+    /**
+     * Given a token, will search for a user having the same activationToken and if
+     * such user exists it will be set to active and its existing token set back to null
+     * @param token
+     * @return boolean
+     */
+    @Transactional
     public boolean validateRegistrationToken(String token) {
-        try {
             AppUser user = userRepository.findByActivationToken(token).orElseThrow();
             user.setIsActive(true);
             user.setActivationToken(null);
+            userRepository.save(user);
+
             return true;
-        } catch (NoSuchElementException e){
-            return false;
-        }
     }
 
-    private String generateRegistrationToken(AppUser registeringUser){
+    /**
+     * Generates a random token to be used to validate registration. Ensures the token
+     * don't already exist beforehand
+     * @return String
+     */
+    private String generateRegistrationToken(){
         Set<String> existingTokens = userRepository.findAllNonNullActivationTokens();
         String activationToken = ActivationTokenUtil.generateToken();;
         boolean mustCreateToken = true;
-        int maxAttempts = 5;
+        int maxAttempts = 10;
         int currentAttempt = 1;
+        // prevent collision with other users existing token
         while(mustCreateToken && currentAttempt <= maxAttempts){
             if (!existingTokens.contains(activationToken)){
                 mustCreateToken = false;

--- a/src/main/java/com/example/bdm/service/AuthService.java
+++ b/src/main/java/com/example/bdm/service/AuthService.java
@@ -2,6 +2,7 @@ package com.example.bdm.service;
 
 import com.example.bdm.dto.RequestLogin;
 import com.example.bdm.dto.RequestRegister;
+import com.example.bdm.exception.ActivationTokenGenerationException;
 import com.example.bdm.exception.EmailAlreadyExistsException;
 import com.example.bdm.exception.NoSuchRoleException;
 import com.example.bdm.exception.UserNotCreatedException;
@@ -10,6 +11,7 @@ import com.example.bdm.model.Role;
 import com.example.bdm.model.enums.AvailableRoles;
 import com.example.bdm.repository.AppUserRepository;
 import com.example.bdm.repository.RoleRepository;
+import com.example.bdm.utils.ActivationTokenUtil;
 import com.example.bdm.utils.JwtUtil;
 import jakarta.servlet.http.Cookie;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +26,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 /**
  * Service dedicated to actions related to signup, login and other features in the layer
@@ -99,5 +103,36 @@ public class AuthService {
         cookie.setPath("/");
         cookie.setMaxAge(0);
         return cookie;
+    }
+
+    public boolean validateRegistrationToken(String token) {
+        try {
+            AppUser user = userRepository.findByActivationToken(token).orElseThrow();
+            user.setIsActive(true);
+            user.setActivationToken(null);
+            return true;
+        } catch (NoSuchElementException e){
+            return false;
+        }
+    }
+
+    private String generateRegistrationToken(AppUser registeringUser){
+        Set<String> existingTokens = userRepository.findAllNonNullActivationTokens();
+        String activationToken = ActivationTokenUtil.generateToken();;
+        boolean mustCreateToken = true;
+        int maxAttempts = 5;
+        int currentAttempt = 1;
+        while(mustCreateToken && currentAttempt <= maxAttempts){
+            if (!existingTokens.contains(activationToken)){
+                mustCreateToken = false;
+            } else {
+                currentAttempt++;
+                activationToken = ActivationTokenUtil.generateToken();
+            }
+        }
+        if(mustCreateToken) {
+            throw new ActivationTokenGenerationException();
+        }
+        return activationToken;
     }
 }

--- a/src/main/java/com/example/bdm/service/EmailService.java
+++ b/src/main/java/com/example/bdm/service/EmailService.java
@@ -1,0 +1,45 @@
+package com.example.bdm.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EmailService {
+    @Value("${app.domain}")
+    private String appDomain;
+    private JavaMailSender mailSender;
+
+    public EmailService(JavaMailSender mailSender){
+        this.mailSender = mailSender;
+    }
+
+    public void sendRegistrationActivationEmail(String userEmail, String token) throws MessagingException {
+        MimeMessage message = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true);
+
+        helper.setFrom("noreply@bdm.com");
+        helper.setTo(userEmail);
+        helper.setSubject("Registration Validation Link");
+
+        String activationLink = appDomain + "/api/auth/"
+
+        String htmlContent = "<html>" +
+                "<body>" +
+                "<h2>Welcome!</h2>" +
+                "<p>Thanks for registering. Please click the link below to fully activate your account:</p>" +
+                "<a href=\"" + activationLink + "\">Activate Account</a>" +
+                "<br/><br/>" +
+                "<p>If you did not register, please ignore this email.</p>" +
+                "</body>" +
+                "</html>";
+
+        helper.setText(htmlContent, true); // true = isHtml
+
+        mailSender.send(message);
+    }
+}

--- a/src/main/java/com/example/bdm/service/EmailService.java
+++ b/src/main/java/com/example/bdm/service/EmailService.java
@@ -1,45 +1,67 @@
 package com.example.bdm.service;
 
+import com.example.bdm.model.AppUser;
+import com.example.bdm.utils.SanitizerUtil;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 @Service
 public class EmailService {
-    @Value("${app.domain}")
     private String appDomain;
     private JavaMailSender mailSender;
+    private SanitizerUtil sanitizerUtil;
 
-    public EmailService(JavaMailSender mailSender){
+    public EmailService(JavaMailSender mailSender,
+                        @Value("${app.domain}") String appDomain,
+                        SanitizerUtil sanitizerUtil
+    ){
         this.mailSender = mailSender;
+        this.appDomain = appDomain;
+        this.sanitizerUtil = sanitizerUtil;
     }
 
-    public void sendRegistrationActivationEmail(String userEmail, String token) throws MessagingException {
+    /**
+     * Sends post registration mail allowing the user to validate their account.
+     * @param user
+     * @param token
+     * @throws MessagingException
+     */
+    public void sendRegistrationActivationEmail(AppUser user, String token) throws MessagingException {
         MimeMessage message = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
         helper.setFrom("noreply@bdm.com");
-        helper.setTo(userEmail);
+        helper.setTo(user.getEmail());
         helper.setSubject("Registration Validation Link");
 
-        String activationLink = appDomain + "/api/auth/"
+        String htmlContent = generateRegistrationMailContent(user, token);
 
+        helper.setText(htmlContent, true);
+        mailSender.send(message);
+    }
+
+    /**
+     * Generate post registration activation mail content
+     * @param user
+     * @param token
+     * @return Stringified html content
+     */
+    private String generateRegistrationMailContent(AppUser user, String token) {
+        String activationLink = appDomain + "/api/auth/activate/" + token;
+        String sanitizedUserName = sanitizerUtil.sanitizeForHtml(user.getFirstName());
         String htmlContent = "<html>" +
                 "<body>" +
                 "<h2>Welcome!</h2>" +
-                "<p>Thanks for registering. Please click the link below to fully activate your account:</p>" +
+                "<p>Thanks for registering "+ sanitizedUserName +". Please click the link below to fully activate your account:</p>" +
                 "<a href=\"" + activationLink + "\">Activate Account</a>" +
                 "<br/><br/>" +
                 "<p>If you did not register, please ignore this email.</p>" +
                 "</body>" +
                 "</html>";
-
-        helper.setText(htmlContent, true); // true = isHtml
-
-        mailSender.send(message);
+        return htmlContent;
     }
 }

--- a/src/main/java/com/example/bdm/utils/ActivationTokenUtil.java
+++ b/src/main/java/com/example/bdm/utils/ActivationTokenUtil.java
@@ -1,0 +1,15 @@
+package com.example.bdm.utils;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class ActivationTokenUtil {
+
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final Base64.Encoder base64Encoder = Base64.getUrlEncoder().withoutPadding();
+
+    public static String generateToken() {
+        byte[] randomBytes = new byte[32];
+        secureRandom.nextBytes(randomBytes);
+        return base64Encoder.encodeToString(randomBytes);
+    }
+}

--- a/src/main/java/com/example/bdm/utils/JwtFilter.java
+++ b/src/main/java/com/example/bdm/utils/JwtFilter.java
@@ -30,12 +30,9 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
-        System.out.println(">>> JwtFilter triggered: " + request.getRequestURI());
         try{
             String jwt = null;
             String username = null;
-
-            System.out.println(">>> STARTING FILTER");
 
             // First: Try to extract token from Authorization header
             final String authHeader = request.getHeader("Authorization");
@@ -53,12 +50,9 @@ public class JwtFilter extends OncePerRequestFilter {
                 }
             }
 
-            System.out.println(">>> JWT : "+jwt);
-
             if (jwt != null) {
                 try {
                     username = jwtUtil.extractUsername(jwt);
-                    System.out.println(">>> 'username' : "+username);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/com/example/bdm/utils/SanitizerUtil.java
+++ b/src/main/java/com/example/bdm/utils/SanitizerUtil.java
@@ -1,0 +1,37 @@
+package com.example.bdm.utils;
+
+import com.example.bdm.dto.RequestRegister;
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class SanitizerUtil {
+
+    /**
+     * escapes html sensible characters from a string to prevent code injection
+     * @param input
+     * @return escaped string
+     */
+    public String sanitizeForHtml(String input){
+        return StringEscapeUtils.escapeHtml4(input.trim());
+    }
+
+    /**
+     * Given a RequestRegister instance, will return a newly made RequestRegister
+     * formed from the sanitization of the given instance's properties
+     * @param inputs
+     * @return sanitized RequestRegister
+     */
+    public RequestRegister sanitizeRegisterInputs(RequestRegister inputs){
+        RequestRegister sanitizedInputs = new RequestRegister();
+        sanitizedInputs.setFirstName(inputs.getFirstName().trim());
+        sanitizedInputs.setLastName(inputs.getLastName().trim());
+        sanitizedInputs.setEmail(inputs.getEmail().trim());
+        sanitizedInputs.setPassword(inputs.getPassword().trim());
+        return sanitizedInputs;
+    }
+
+}

--- a/src/main/java/com/example/bdm/utils/ValidatorUtil.java
+++ b/src/main/java/com/example/bdm/utils/ValidatorUtil.java
@@ -1,0 +1,66 @@
+package com.example.bdm.utils;
+
+import com.example.bdm.dto.RequestRegister;
+import com.example.bdm.exception.InvalidRegistrationInputException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ValidatorUtil {
+    private final int UserNameMin = 3;
+    private final int UserNameMax = 30;
+    private final int passwordMin = 8;
+    private String userNameRegex;
+    private final String emailRegex = "^[\\w.-]+@[\\w.-]+\\.[a-zA-Z]{2,4}$";
+
+    ValidatorUtil(){
+        // using %d has an integer positional format specifier for placeholder to
+        // replace by two following variables when building the string
+        this.userNameRegex = String.format("^[\\p{L} .'-]{%d,%d}$", UserNameMin, UserNameMax);
+    }
+
+    public boolean isValidFirstName(String input) {
+        if(input == null) {return false;}
+        String trimedInput = input.trim();
+        return trimedInput.matches(userNameRegex);
+    }
+    public boolean isValidLastName(String input) {
+        if(input == null) {return false;}
+        String trimedInput = input.trim();
+        return trimedInput.matches(userNameRegex);
+    }
+    public boolean isValidEmail(String input) {
+        if(input == null) {return false;}
+        String trimedInput = input.trim();
+        return trimedInput.matches(emailRegex);
+    }
+    public boolean isValidPassword(String input) {
+        if(input == null) {return false;}
+        return input.trim().length() >= passwordMin;
+    }
+
+    /**
+     * For all inputs in a RequestRegister this method applies validation and will
+     * return a list of all errors.
+     * @param inputs RequestRegister instance representing signup data
+     * @return List of error strings or empty list if no error
+     */
+    public List<String> validateRegisterInputs(RequestRegister inputs){
+        List<String> errors = new ArrayList<>();
+        if(!isValidFirstName(inputs.getFirstName())){
+            errors.add("first name must have between "+UserNameMin+" and "+UserNameMax+" characters");
+        }
+        if(!isValidLastName(inputs.getLastName())){
+            errors.add("last name must have between "+UserNameMin+" and "+UserNameMax+" characters");
+        }
+        if(!isValidEmail(inputs.getEmail())){
+            errors.add("email format is invalid");
+        }
+        if(!isValidPassword(inputs.getPassword())){
+            errors.add("password must have at least "+passwordMin+" characters");
+        }
+        return errors;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -16,3 +16,13 @@ app.jwt.expirationMs=86400000
 
 #Allowed cors origin for dev
 cors.allowed-origin=http://localhost:4200
+
+#App domain used for mailing and registration token url generation
+app.domain=http://localhost:8080
+
+spring.mail.host=sandbox.smtp.mailtrap.io
+spring.mail.port=2525
+spring.mail.username=d5ce520486e298
+spring.mail.password=1ee7c8645010f3
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -10,6 +10,9 @@ spring.jpa.hibernate.ddl-auto=create-drop
 #logging.level.org.hibernate.SQL=DEBUG
 #logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
+#App domain used for mailing and registration token url generation
+app.domain=http://localhost:8080
+
 #Test JWT
 app.jwt.secret=nj7kab3zhoijenDI3U54a6uPPndz2i3D3ESa9m7s6ppze80XGsd3AP
 app.jwt.expirationMs=86400000

--- a/src/test/java/com/example/bdm/BdmApplicationTests.java
+++ b/src/test/java/com/example/bdm/BdmApplicationTests.java
@@ -2,12 +2,13 @@ package com.example.bdm;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
+@Import(TestConfig.class)
 class BdmApplicationTests {
-
 	@Test
 	void contextLoads() {
 	}

--- a/src/test/java/com/example/bdm/TestConfig.java
+++ b/src/test/java/com/example/bdm/TestConfig.java
@@ -1,0 +1,16 @@
+package com.example.bdm;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    @Primary
+    public JavaMailSender javaMailSender() {
+        return Mockito.mock(JavaMailSender.class);
+    }
+}

--- a/src/test/java/com/example/bdm/controller/AppUserControllerTest.java
+++ b/src/test/java/com/example/bdm/controller/AppUserControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.bdm.controller;
 
+import com.example.bdm.TestConfig;
 import com.example.bdm.dto.RequestUserGdprUpdate;
 import com.example.bdm.model.AppUser;
 import com.example.bdm.model.Role;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockCookie;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -39,6 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestConfig.class)
 class AppUserControllerTest {
     @Autowired
     private AppUserRepository userRepository;

--- a/src/test/java/com/example/bdm/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/bdm/controller/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.bdm.controller;
 
+import com.example.bdm.TestConfig;
 import com.example.bdm.config.JwtProperties;
 import com.example.bdm.dto.RequestLogin;
 import com.example.bdm.dto.RequestRegister;
@@ -13,15 +14,20 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -46,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestConfig.class)
 class AuthControllerTest {
     @Autowired
     private AppUserRepository userRepository;
@@ -63,6 +70,9 @@ class AuthControllerTest {
     @Autowired
     private JwtProperties jwtProperties;
 
+    @Autowired
+    private JavaMailSender mailSender;
+
     private Role roleAdmin;
     private Role roleUser;
 
@@ -75,6 +85,12 @@ class AuthControllerTest {
     @BeforeEach
     void setUp() {
         userRepository.deleteAll();
+    }
+
+    @BeforeEach
+    public void setupMockMailSender() {
+        MimeMessage mimeMessage = new MimeMessage((Session) null); // use default Session
+        Mockito.when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
     }
 
     @Test
@@ -100,6 +116,23 @@ class AuthControllerTest {
                 passwordEncoder.matches(registerData.getPassword(), createdUser.getPassword()),
                 "Hashed password should match clear password"
         );
+    }
+
+    @Test
+    @Transactional
+    void testRegisterUser_GivenFullInvalidRequest_ReturnsBadRequestAndAllErrorMessage() throws Exception {
+        RequestRegister registerData = new RequestRegister(
+                        "J",
+                        "D",
+                        "john.doe@test.t",
+                        "Test"
+        );
+
+        mockMvc.perform(post("/api/auth/signup")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerData)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errors.length()").value(4));
     }
 
     @Test

--- a/src/test/java/com/example/bdm/controller/RoleControllerTest.java
+++ b/src/test/java/com/example/bdm/controller/RoleControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.bdm.controller;
 
+import com.example.bdm.TestConfig;
 import com.example.bdm.model.Role;
 import com.example.bdm.repository.RoleRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -27,7 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(TestConfig.class)
 class RoleControllerTest {
+
     @Autowired
     private RoleRepository roleRepository;
 

--- a/src/test/java/com/example/bdm/utils/ValidatorUtilTest.java
+++ b/src/test/java/com/example/bdm/utils/ValidatorUtilTest.java
@@ -1,0 +1,85 @@
+package com.example.bdm.utils;
+
+import com.example.bdm.dto.RequestRegister;
+import com.example.bdm.exception.InvalidRegistrationInputException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ValidatorUtilTest {
+    @Autowired
+    ValidatorUtil validatorUtil;
+
+    @Test
+    void testIsValidFirstName() {
+        String tooLongName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assertFalse(validatorUtil.isValidFirstName("a"), "Should return false if too short");
+        assertFalse(validatorUtil.isValidFirstName(tooLongName), "Should return false if too long");
+        assertTrue(validatorUtil.isValidFirstName("valid"), "Should return true if valid");
+    }
+
+    @Test
+    void testIsValidLastName() {
+        String tooLongName = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assertFalse(validatorUtil.isValidLastName("a"), "Should return false if too short");
+        assertFalse(validatorUtil.isValidLastName(tooLongName), "Should return false if too long");
+        assertTrue(validatorUtil.isValidLastName("valid"), "Should return true if valid");
+    }
+
+    @Test
+    void testIsValidEmail() {
+        String invalidEmail = "valid@test.t";
+        String validEmail = "valid@test.test";
+        assertFalse(validatorUtil.isValidEmail(invalidEmail), "Should return false if wrong format");
+        assertTrue(validatorUtil.isValidEmail(validEmail), "Should return true if valid");
+    }
+
+    @Test
+    void testIsValidPassword() {
+        String invalidPassword = "123";
+        String validPassword = "12345678";
+        assertFalse(validatorUtil.isValidPassword(invalidPassword), "Should return false if too short");
+        assertTrue(validatorUtil.isValidPassword(validPassword), "Should return true valid");
+    }
+
+    @Test
+    void testValidateRegisterInputs_GivenValidInputs_ReturnsNoError() {
+        RequestRegister inputs = new RequestRegister(
+                "John",
+                "Doe",
+                "john.d@test.test",
+                "12345678"
+        );
+        List<String> errors = validatorUtil.validateRegisterInputs(inputs);
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void testValidateRegisterInputs_GivenAllInvalidInputs_ReturnsAllErrors() {
+        RequestRegister inputs = new RequestRegister(
+                "J",
+                "D",
+                "john.d@test.t",
+                "1234567"
+        );
+
+        List<String> expectedError = List.of(
+                "first name must have between 3 and 30 characters",
+                "last name must have between 3 and 30 characters",
+                "email format is invalid",
+                "password must have at least 8 characters"
+                );
+
+        List<String> errors = validatorUtil.validateRegisterInputs(inputs);
+
+        assertEquals(expectedError.get(0), errors.get(0));
+        assertEquals(expectedError.get(1), errors.get(1));
+        assertEquals(expectedError.get(2), errors.get(2));
+        assertEquals(expectedError.get(3), errors.get(3));
+    }
+}


### PR DESCRIPTION
Implemented a feature that will send a mail on registration providing a link to validate the user.

- Added dependency "spring-boot-starter-mail" (org.springframework.boot) for handling email.
- Added dependency "commons-text" (org.apache.commons) for extra sanitization and preventing eventual xss when generating email content.
⚠Mail feature requires adding a TestConfig import on test classes requiring a Spring boot context in order to mock the bean or the build will fail.

Added extra validation of user registration data like length requirement for first and last name, for password and also for the email format.